### PR TITLE
BUG: Example (VectorKernelPCA) was missing dependencies

### DIFF
--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -4,9 +4,10 @@ principal component analysis for the ITK toolkit.")
 itk_module(PrincipalComponentsAnalysis
   DEPENDS
     ITKCommon
-  TEST_DEPENDS
-    ITKIOMesh
     ITKMesh
+    ITKIOMesh
+    ITKIOImageBase
+  TEST_DEPENDS
     ITKTestKernel
   EXCLUDE_FROM_DEFAULT 
   DESCRIPTION


### PR DESCRIPTION
ITKMesh, ITKIOMesh, and ITKIOImageBase modules are required to build
VectorKernelPCA.
